### PR TITLE
Fixing error in ceiling according to my experience

### DIFF
--- a/java/com/messente/util/SmsLengthCalculator.java
+++ b/java/com/messente/util/SmsLengthCalculator.java
@@ -64,7 +64,7 @@ public class SmsLengthCalculator {
         } else {
 
             // Start counting the number of messages
-            int parts = (int)Math.ceil(content7bit.length() / 153.0);
+            int parts = (content7bit.length() - 1) / 153.0 + 1;
             int free_chars = content7bit.length() - (int)Math.floor(content7bit.length() / 153.0)*153;
 
             // We have enough free characters left, don't care about escape character at the end of sms part
@@ -107,7 +107,7 @@ public class SmsLengthCalculator {
             if (content.length() <= 70) {
                 return 1;
             } else {
-                return (int)Math.ceil(content.length() / 67.0);
+                return (content.length() - 1) / 67.0 + 1;
             }
 
         }


### PR DESCRIPTION
I have implemented and enhanced this code in Talend open Studio 6.3.1 in JDK 7 & JDK 8.
I got an misbehave from ceiling function, but it worked well if I tried in the IDE.
Then I implemented article below and worked well.
I think it will be safer to use manual rounded up function rather than use ceiling or casting, according to the result of the String.length() is int as well.

https://stackoverflow.com/questions/7139382/java-rounding-up-to-an-int-using-math-ceil